### PR TITLE
restrict git clone command to a commit history depth of 1

### DIFF
--- a/inc/app-git-download.sh
+++ b/inc/app-git-download.sh
@@ -1,5 +1,5 @@
 echo
 sleep 1
 echo -e $YELLOW'--->Downloading latest '$APPTITLE'...'$ENDCOLOR
-git clone $APPGIT $APPPATH || { echo -e $RED'Git not found.'$ENDCOLOR ; exit 1; }
+git clone --depth 1 $APPGIT $APPPATH || { echo -e $RED'Git not found.'$ENDCOLOR ; exit 1; }
 source $SCRIPTPATH/inc/app-set-permissions.sh


### PR DESCRIPTION
I don't see any contributing guide for this repo, so I went with something simple and pretty common for this PR.. Hope that's ok. :)

Anyway, what about restricting the commit history depth when installing the different apps? Some app repos (Sonarr for example) fast-forward all their commits when merging feature/fix branches, so their `master` repo has thousands of commit messages and diffs. Seems kinda wasteful to me, considering it's not intended for development..
