### PR TITLE
Edited method of finding the script path

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,13 @@
 
 # Set caller id and script path
 export CALLER=$(ps ax | grep "^ *$PPID" | awk '{print $NF}')
-export SCRIPTPATH=$(pwd)
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+export SCRIPTPATH="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 if [[ $0 == *"setup.sh"* ]]
 then


### PR DESCRIPTION
This change allows the setup.sh to be run as a symlink in the usr/local/bin or anywhere else. Part of my easier easy toolkit! I am trying to make a one step install so one command can be copied and the atomic toolkit is installed and run. 