### PR TITLE
Fixed CouchPotato backup

### DIFF
--- a/couchpotato/couchpotato-backup-files
+++ b/couchpotato/couchpotato-backup-files
@@ -1,4 +1,4 @@
-APPPATH/settings.conf
+APPPATH/data/settings.conf
 APPPATH/data/cache
 APPPATH/data/database
 APPPATH/data/db_backup


### PR DESCRIPTION
Settings.conf is located in the data dir. I've changed the backup file location to reflect this. 

Thanks for bringing this to my attention.

"Closes #204"